### PR TITLE
fix: add legacy-peer-deps to resolve Cloudflare build dependency conf…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
…lict

wrangler@4.118.0 requires @cloudflare/workers-types@^5 but the Cloudflare build environment has v4 pre-installed, causing ERESOLVE on npx next-on-pages.